### PR TITLE
feat: add TCE metrics API env var

### DIFF
--- a/tce.yml
+++ b/tce.yml
@@ -23,6 +23,7 @@ services:
       - TCE_DB_PATH=/tmp/default-db
       - TCE_API_ADDR=0.0.0.0:1340
       - TCE_GRAPHQL_API_ADDR=0.0.0.0:4000
+      - TCE_METRICS_API_ADDR=0.0.0.0:4001
       - TCE_LOCAL_KS=1 # 12D3KooWRhFCXBhmsMnur3up3vJsDoqWh4c39PKXgSWwzAzDHNLn
       - TOPOS_OTLP_SERVICE_NAME=local-tce-boot-node
       - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
@@ -62,6 +63,7 @@ services:
       - TCE_DB_PATH=/tmp/default-db
       - TCE_API_ADDR=0.0.0.0:1340
       - TCE_GRAPHQL_API_ADDR=0.0.0.0:4000
+      - TCE_METRICS_API_ADDR=0.0.0.0:4001
       - TOPOS_OTLP_SERVICE_NAME=local-tce-peer-node
       - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
       - TCE_ECHO_SAMPLE_SIZE=4


### PR DESCRIPTION
# Description

This PR adds the `TCE_METRICS_API_ADDR` env variable for TCE nodes so that it doesn't use the default `3000` port that is already used by other stack components.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
