### PR TITLE
test: trigger frontend e2e tests

### DIFF
--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -1,0 +1,20 @@
+name: Run e2e tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: topos-protocol
+          repo: e2e-tests
+          github_token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
+          workflow_file_name: frontend:erc20-messaging.yml
+          ref: main
+          wait_interval: 60
+          client_payload: '{ "local-erc20-messaging-infra-ref": "${{ github.head_ref }}" }'

--- a/tce.yml
+++ b/tce.yml
@@ -26,14 +26,14 @@ services:
       - TCE_METRICS_API_ADDR=0.0.0.0:4001
       - TCE_LOCAL_KS=1 # 12D3KooWRhFCXBhmsMnur3up3vJsDoqWh4c39PKXgSWwzAzDHNLn
       - TOPOS_OTLP_SERVICE_NAME=local-tce-boot-node
-      - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
+      - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.topos.technology
       - TCE_ECHO_SAMPLE_SIZE=4
       - TCE_READY_SAMPLE_SIZE=4
       - TCE_DELIVERY_SAMPLE_SIZE=4
       - TCE_ECHO_THRESHOLD=3
       - TCE_READY_THRESHOLD=1
       - TCE_DELIVERY_THRESHOLD=2
-      - TOPOS_MINIMUM_TCE_CLUSTER_SIZE=2
+      - TOPOS_MINIMUM_TCE_CLUSTER_SIZE=3
     networks:
       - local-erc20-messaging-infra-docker
 
@@ -65,14 +65,14 @@ services:
       - TCE_GRAPHQL_API_ADDR=0.0.0.0:4000
       - TCE_METRICS_API_ADDR=0.0.0.0:4001
       - TOPOS_OTLP_SERVICE_NAME=local-tce-peer-node
-      - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
+      - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.topos.technology
       - TCE_ECHO_SAMPLE_SIZE=4
       - TCE_READY_SAMPLE_SIZE=4
       - TCE_DELIVERY_SAMPLE_SIZE=4
       - TCE_ECHO_THRESHOLD=3
       - TCE_READY_THRESHOLD=1
       - TCE_DELIVERY_THRESHOLD=2
-      - TOPOS_MINIMUM_TCE_CLUSTER_SIZE=2
+      - TOPOS_MINIMUM_TCE_CLUSTER_SIZE=3
     networks:
       - local-erc20-messaging-infra-docker
 


### PR DESCRIPTION
# Description

This PR adds a trigger to run frontend-erc20 e2e tests on infra's updates.

Additionally, it increase the minimum TCE cluster size value from `2` to `3` to fix recent failing e2e tests.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
