### PR TITLE
chore: update subnet json-rpc env var

### DIFF
--- a/subnet-incal.yml
+++ b/subnet-incal.yml
@@ -159,11 +159,11 @@ services:
       - RUST_LOG=info,topos=debug
       - TOOLCHAIN_VERSION=stable
       - RUST_BACKTRACE=full
-      - SUBNET_JSONRPC_ENDPOINT=incal-node-1:8545
-      - TOPOS_LOCAL_SUBNET_DATA_DIR=/data/data-1
       - TOPOS_BASE_TCE_API_URL=http://infra-tce-boot-1:1340
+      - TOPOS_LOCAL_SUBNET_DATA_DIR=/data/data-1
       - TOPOS_OTLP_SERVICE_NAME=local-incal-sequencer
       - TOPOS_OTLP_AGENT=https://otel-collector.telemetry.devnet-1.toposware.com
+      - TOPOS_SUBNET_JSONRPC_HTTP=incal-node-1:8545
     networks:
       - local-erc20-messaging-infra-docker
 

--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -157,11 +157,11 @@ services:
       - RUST_LOG=info,topos=debug
       - TOOLCHAIN_VERSION=stable
       - RUST_BACKTRACE=full
-      - SUBNET_JSONRPC_ENDPOINT=topos-node-1:8545
-      - TOPOS_LOCAL_SUBNET_DATA_DIR=/data/data-1
       - TOPOS_BASE_TCE_API_URL=http://infra-tce-boot-1:1340
+      - TOPOS_LOCAL_SUBNET_DATA_DIR=/data/data-1
       - TOPOS_OTLP_SERVICE_NAME=local-topos-sequencer
       - TOPOS_OTLP_AGENT=https://otel-collector.telemetry.devnet-1.toposware.com
+      - TOPOS_SUBNET_JSONRPC_HTTP=topos-node-1:8545
     networks:
       - local-erc20-messaging-infra-docker
 


### PR DESCRIPTION
# Description

This PR adds a BREAKING CHANGE that consists in updating sequencers' env var for their related subnet's JSON-RPC API endpoint.

## Breaking changes

- Sequencer env var name update: `SUBNET_JSONRPC_ENDPOINT` -> `TOPOS_SUBNET_JSONRPC_HTTP`

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
