### PR TITLE
ci(e2e-tests): remove explicit topos version

### DIFF
--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -17,4 +17,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "local-erc20-messaging-infra-ref": "${{ github.head_ref }}", "topos-docker-tag": "main" }'
+          client_payload: '{ "local-erc20-messaging-infra-ref": "${{ github.head_ref }}" }'


### PR DESCRIPTION
# Description

This PR removes the wrongly added explicit version of `topos` in the e2e-tests CI workflow.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
