### PR TITLE
fix: remove the custom topos tag

### DIFF
--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -17,5 +17,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          # Remove topos-docker-tag when https://github.com/topos-protocol/topos/pull/386 is merged
-          client_payload: '{ "local-erc20-messaging-infra-ref": "${{ github.head_ref }}", "topos-docker-tag": "pr-386" }'
+          client_payload: '{ "local-erc20-messaging-infra-ref": "${{ github.head_ref }}" }'

--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -91,7 +91,7 @@ services:
       - "3030:3030"
       - "4030:4030"
     environment:
-      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug,topos::edge=off
+      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug
     networks:
       - local-erc20-messaging-infra-docker
 
@@ -127,7 +127,7 @@ services:
       - "3030"
       - "4030"
     environment:
-      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug,topos::edge=off
+      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug
     networks:
       - local-erc20-messaging-infra-docker
 
@@ -163,7 +163,7 @@ services:
       - "3030"
       - "4030"
     environment:
-      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug,topos::edge=off
+      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug
     networks:
       - local-erc20-messaging-infra-docker
 
@@ -199,7 +199,7 @@ services:
       - "3030"
       - "4030"
     environment:
-      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug,topos::edge=off
+      - RUST_LOG=topos=debug,topos_tce_storage=debug,topos_tce_synchronizer=debug
     networks:
       - local-erc20-messaging-infra-docker
 


### PR DESCRIPTION
# Description

Remove the custom docker tag needed during the transition of changes on the topos CLI

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
