### PR TITLE
feat: add network health check test

### DIFF
--- a/subnet-incal.yml
+++ b/subnet-incal.yml
@@ -175,7 +175,6 @@ services:
         condition: service_healthy
     entrypoint: ""
     command: bash -c "
-      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       cp -vr /data/data-1/consensus /tmp/node_config/node/sequencer-incal/consensus &&
       cp -vr /data/data-1/libp2p /tmp/node_config/node/sequencer-incal/libp2p &&

--- a/subnet-incal.yml
+++ b/subnet-incal.yml
@@ -175,6 +175,7 @@ services:
         condition: service_healthy
     entrypoint: ""
     command: bash -c "
+      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       cp -vr /data/data-1/consensus /tmp/node_config/node/sequencer-incal/consensus &&
       cp -vr /data/data-1/libp2p /tmp/node_config/node/sequencer-incal/libp2p &&

--- a/subnet-incal.yml
+++ b/subnet-incal.yml
@@ -175,6 +175,7 @@ services:
         condition: service_healthy
     entrypoint: ""
     command: bash -c "
+      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       cp -vr /data/data-1/consensus /tmp/node_config/node/sequencer-incal/consensus &&
       cp -vr /data/data-1/libp2p /tmp/node_config/node/sequencer-incal/libp2p &&
@@ -182,6 +183,10 @@ services:
       cp -v /data/genesis.json /tmp/node_config/subnet/incal/genesis.json  &&
       echo Topos core contract address=$(printenv TOPOS_CORE_PROXY_CONTRACT_ADDRESS), set manually in config &&
       topos node up --name sequencer-incal --home /tmp/node_config --no-edge-process"
+    healthcheck:
+      test: ["CMD-SHELL", "test $(netstat -ntu | grep ':8545' | wc -l) -gt 0"]
+      interval: 1s
+      retries: 10
     environment:
       - RUST_LOG=info,topos=debug
       - TOOLCHAIN_VERSION=stable

--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -235,7 +235,6 @@ services:
         condition: service_completed_successfully
     entrypoint: ""
     command: bash -c "
-      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       mkdir -p /data/node/sequencer-topos/consensus -p /data/node/sequencer-topos/libp2p -p /data/subnet/topos-sequencer/ &&
       cp -vr /data/node/node-1/consensus /data/node/sequencer-topos/ &&

--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -235,6 +235,7 @@ services:
         condition: service_completed_successfully
     entrypoint: ""
     command: bash -c "
+      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       mkdir -p /data/node/sequencer-topos/consensus -p /data/node/sequencer-topos/libp2p -p /data/subnet/topos-sequencer/ &&
       cp -vr /data/node/node-1/consensus /data/node/sequencer-topos/ &&

--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -235,6 +235,7 @@ services:
         condition: service_completed_successfully
     entrypoint: ""
     command: bash -c "
+      apt-get update && apt-get install -y net-tools &&
       source /contracts/.env &&
       mkdir -p /data/node/sequencer-topos/consensus -p /data/node/sequencer-topos/libp2p -p /data/subnet/topos-sequencer/ &&
       cp -vr /data/node/node-1/consensus /data/node/sequencer-topos/ &&
@@ -242,6 +243,10 @@ services:
       cp -vr /data/subnet/topos/genesis.json /data/subnet/topos-sequencer/genesis.json &&
       echo \"Topos Core contract address:\" $(printenv TOPOS_CORE_PROXY_CONTRACT_ADDRESS), set manually in config &&
       topos node up --name sequencer-topos --home /data/ --no-edge-process"
+    healthcheck:
+      test: ["CMD-SHELL", "test $(netstat -ntu | grep ':8545' | wc -l) -gt 0"]
+      interval: 1s
+      retries: 10
     environment:
       - RUST_LOG=info,topos=debug
       - TOOLCHAIN_VERSION=stable

--- a/tests/test_network_health.sh
+++ b/tests/test_network_health.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+source $LOCAL_ERC20_HOME/tests/utils.sh
+
+
+network_started=0
+
+# Start network if it is not running
+is_running=$(is_network_running)
+if [ $is_running -eq 1 ]; then
+    echo "Test network is not running, starting it now..."
+    start_network
+    network_started=1
+    sleep 5 # Warm up network
+fi
+
+
+# Perform test
+echo "Executing network health check test..."
+# Check if all relevant containers are healthy
+for i in {1..10};
+do
+    network_healthy=$(check_network_health)
+    if [ $network_healthy -eq 0 ]; then
+        echo "Network is healthy"
+        break
+    else
+        echo "Network is NOT healthy"
+        if [[ "$i" != '10' ]]; then
+            echo "Trying again in 5 seconds for $(($i+1)) time"
+            sleep 5
+            continue
+        fi
+        if [ $network_started -eq 1 ]; then
+            echo "Test failed, shutting down network started for this test"
+            stop_network
+        fi        
+        exit 1
+    fi
+done
+
+
+
+# Stop network if started for this test
+if [ $network_started -eq 1 ]; then
+    echo "Shutting down network started for this test"
+    stop_network
+fi

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -21,18 +21,13 @@ stop_network () {
 
 check_network_health () {
     # Check if all relevant containers are healthy
-    # TODO: Add healcheck for sequencers, currenly only tce and polygon edge nodes are checked
-    SERVICE_NAMES=$(docker compose config --dry-run --services | grep -e node)
+    SERVICE_NAMES=$(docker compose config --dry-run --services | grep -e node -e sequencer)
     EXPECTED=$(docker compose ps -aq $SERVICE_NAMES | wc -l)
     COUNT=$(docker inspect --format "{{.State.Health.Status }}" $(docker compose ps -aq $SERVICE_NAMES) | grep "^healthy$"|wc -l)
-    echo "Number of Healthy containers: $COUNT"
     if [[ $COUNT -eq $EXPECTED ]]; then
-        echo "All expected containers healthy"
-        return 0
+        echo 0
     else
-        echo "Unhealthy containers"
-        docker compose -f tools/docker-compose.yml ps -a peer boot
-        return 1
+        echo 1
     fi
 }
 


### PR DESCRIPTION
# Description

This PR adds a test for checking the health of the `topos-nodes`, `incal-nodes` and the relative sequencers for both the subnets.

Fixes TP-812

## Additions and Changes

- Added the `healthcheck` for `topos-sequencer` & `incal-sequencer`
- Added a `test_network_health` script to run the test

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
