### PR TITLE
chore: bump contracts version to 3.3.0

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@ REDIS_PORT=6379
 TOPOS_EDGE_VERSION=1.3.0-topos
 
 # Find latest here: https://github.com/topos-protocol/topos-smart-contracts/releases
-TOPOS_MESSAGING_PROTOCOL_CONTRACTS_VERSION=3.2.0
+TOPOS_MESSAGING_PROTOCOL_CONTRACTS_VERSION=3.3.0
 
 # Find latest here: https://github.com/topos-protocol/topos/releases
 TOPOS_VERSION=0.0.11


### PR DESCRIPTION
# Description

Bump `topos-smart-contracts` from `v3.2.0` to `v3.3.0`

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
