### PR TITLE
chore: topos reference

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ TOPOS_EDGE_VERSION=1.3.0-topos
 TOPOS_MESSAGING_PROTOCOL_CONTRACTS_VERSION=3.3.0
 
 # Find latest here: https://github.com/topos-protocol/topos/releases
-TOPOS_VERSION=0.0.11
+TOPOS_VERSION=main
 
 # Find latest here: https://github.com/topos-protocol/executor-service/releases
 EXECUTOR_SERVICE_VERSION=1.2.0


### PR DESCRIPTION
# Description

Bump topos version to always use main docker tag (head of topos main branch image)


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
