### PR TITLE
chore: remove hard deps between nodes

### DIFF
--- a/subnet-topos.yml
+++ b/subnet-topos.yml
@@ -118,14 +118,14 @@ services:
         set -e
         ./topos node status --node http://localhost:1340
         /data/polygon-edge status | grep 'Current Block Number (base 10) = .[0-9]*'
-      interval: 10s
+      interval: 5s
       start_period: 1s
       retries: 10
     depends_on:
       topos-init:
         condition: service_completed_successfully
       topos-node-1:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - topos-data:/data
       - ./node_config/node/topos-node-2/config.toml:/data/node/node-2/config.toml:ro
@@ -158,14 +158,14 @@ services:
         set -e
         ./topos node status --node http://localhost:1340
         /data/polygon-edge status | grep 'Current Block Number (base 10) = .[0-9]*'
-      interval: 10s
+      interval: 5s
       start_period: 1s
       retries: 10
     depends_on:
       topos-init:
         condition: service_completed_successfully
       topos-node-1:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - topos-data:/data
       - ./node_config/node/topos-node-3/config.toml:/data/node/node-3/config.toml:ro
@@ -198,14 +198,14 @@ services:
         set -e
         ./topos node status --node http://localhost:1340
         /bin/sh /polygon_edge_healthcheck.sh /data
-      interval: 10s
+      interval: 5s
       start_period: 1s
       retries: 10
     depends_on:
       topos-init:
         condition: service_completed_successfully
       topos-node-1:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - topos-data:/data
       - ./node_config/node/topos-node-4/config.toml:/data/node/node-4/config.toml:ro
@@ -232,13 +232,14 @@ services:
       - ./node_config/node/sequencer-topos/config.toml:/data/node/sequencer-topos/config.toml
     depends_on:
       topos-node-4:
-        condition: service_healthy
+        condition: service_started
       contracts-topos:
         condition: service_completed_successfully
     entrypoint: "bash -c"
     command: /tmp/init.sh
     healthcheck:
       test: ["CMD-SHELL", "test $(netstat -ntu | grep ':8545' | wc -l) -gt 0"]
+      start_period: 15s
       interval: 1s
       retries: 10
     environment:


### PR DESCRIPTION
# Description

This PR removes the `service_healthy` status of the topos node and switch to `service_started`.
In the current setup there is only one bootnode where normally we should have more.

(this is linked to this [PR](https://github.com/topos-protocol/topos/pull/464) on topos)

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
